### PR TITLE
Fix preprocessor loading with consistent sklearn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ openai
 pandas
 plotly
 numpy
-scikit-learn
+scikit-learn==1.5.2
 joblib
 matplotlib
 dotenv

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,13 @@
 import joblib
 import os
+import sys
+
+# Ensure the custom transformer used in the preprocessing pipeline is
+# available when unpickling the joblib artifact. This import is not used
+# directly in the code, but joblib requires it to locate the class
+# definition.
+sys.path.append(os.path.dirname(__file__))
+from preprocessing_pipeline import FeatureEngineer  # noqa: F401
 
 # model = joblib.load("../model/employee_attrition_model.pkl")
 # preprocessor = joblib.load("../artifacts/preprocessor_pipeline.pkl")


### PR DESCRIPTION
## Summary
- ensure custom transformer is importable before loading joblib files
- pin `scikit-learn` to 1.5.2 so saved models load correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68501eba7d5c8329931c68441ab5c8ad